### PR TITLE
Add log management and improve visualization filters

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -19,7 +19,8 @@ function App() {
       const storedActions = await getLocalData('actions');
       const storedLogs = await getLocalData('logs');
       setActions(storedActions || []);
-      setLogs(storedLogs || []);
+      const now = Date.now();
+      setLogs((storedLogs || []).map((log, index) => ({ id: log.id ?? now + index, ...log })));
       setIsDataLoaded(true);
     })();
   }, []);

--- a/client/src/components/Actionsbar.js
+++ b/client/src/components/Actionsbar.js
@@ -5,7 +5,7 @@ import { List, ListItem, ListItemText, IconButton, Divider, Typography, Box } fr
 import { Edit, Delete } from '@mui/icons-material';
 
 const Actionsbar = () => {
-    const { actions, setActions } = useContext(DataContext);
+    const { actions, setActions, logs, setLogs } = useContext(DataContext);
     const [editAction, setEditAction] = useState(null);
 
     const handleSave = (action) => {
@@ -22,7 +22,10 @@ const Actionsbar = () => {
     };
 
     const handleDelete = (id) => {
+        // Remove the action
         setActions(actions.filter((a) => a.id !== id));
+        // Remove any logs associated with this action
+        setLogs(logs.filter((log) => log.actionId !== id));
         if (editAction && editAction.id === id) setEditAction(null);
     };
 

--- a/client/src/components/LogAction.js
+++ b/client/src/components/LogAction.js
@@ -8,7 +8,10 @@ const LogAction = () => {
 
     const handleLog = () => {
         if (selectedAction !== null) {
-            setLogs([...logs, { actionId: selectedAction, timestamp: new Date().toISOString() }]);
+            setLogs([
+                ...logs,
+                { id: Date.now(), actionId: selectedAction, timestamp: new Date().toISOString() }
+            ]);
             setSelectedAction(null);
         }
     };

--- a/client/src/components/LogList.js
+++ b/client/src/components/LogList.js
@@ -1,0 +1,79 @@
+import React, { useContext, useState } from 'react';
+import { DataContext } from '../context/DataContext';
+import { List, ListItem, ListItemText, IconButton, Dialog, DialogTitle, DialogContent, DialogActions, Button, TextField, Box } from '@mui/material';
+import { Edit, Delete } from '@mui/icons-material';
+import { format, parseISO } from 'date-fns';
+
+const LogList = () => {
+  const { logs, setLogs, actions } = useContext(DataContext);
+  const [editingLog, setEditingLog] = useState(null);
+  const [editTime, setEditTime] = useState('');
+
+  const handleEdit = (log) => {
+    setEditingLog(log);
+    setEditTime(format(parseISO(log.timestamp), "yyyy-MM-dd'T'HH:mm"));
+  };
+
+  const handleSave = () => {
+    setLogs(
+      logs.map((l) =>
+        l.id === editingLog.id
+          ? { ...l, timestamp: new Date(editTime).toISOString() }
+          : l
+      )
+    );
+    setEditingLog(null);
+  };
+
+  const handleDelete = (id) => {
+    setLogs(logs.filter((l) => l.id !== id));
+  };
+
+  return (
+    <Box>
+      <List>
+        {logs.map((log) => {
+          const action = actions.find((a) => a.id === log.actionId);
+          return (
+            <ListItem
+              key={log.id}
+              secondaryAction={
+                <Box>
+                  <IconButton edge="end" onClick={() => handleEdit(log)}>
+                    <Edit />
+                  </IconButton>
+                  <IconButton edge="end" onClick={() => handleDelete(log.id)}>
+                    <Delete />
+                  </IconButton>
+                </Box>
+              }
+            >
+              <ListItemText
+                primary={action ? action.name : 'Unknown Action'}
+                secondary={format(parseISO(log.timestamp), 'Pp')}
+              />
+            </ListItem>
+          );
+        })}
+      </List>
+
+      <Dialog open={Boolean(editingLog)} onClose={() => setEditingLog(null)}>
+        <DialogTitle>Edit Log Time</DialogTitle>
+        <DialogContent>
+          <TextField
+            type="datetime-local"
+            value={editTime}
+            onChange={(e) => setEditTime(e.target.value)}
+            fullWidth
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setEditingLog(null)}>Cancel</Button>
+          <Button variant="contained" onClick={handleSave}>Save</Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+};
+
+export default LogList;

--- a/client/src/pages/ActionPage.js
+++ b/client/src/pages/ActionPage.js
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Grid, Paper, Typography } from '@mui/material';
+import { Grid, Paper, Typography, Divider } from '@mui/material';
 import Actionsbar from '../components/Actionsbar';
 import LogAction from '../components/LogAction';
+import LogList from '../components/LogList';
 
 const ActionPage = () => (
     <Grid container spacing={2}>
@@ -16,6 +17,11 @@ const ActionPage = () => (
                     Log Your Actions
                 </Typography>
                 <LogAction />
+                <Divider sx={{ my: 2 }} />
+                <Typography variant="h6" gutterBottom>
+                    Logged Actions
+                </Typography>
+                <LogList />
             </Paper>
         </Grid>
     </Grid>

--- a/client/src/pages/VisualizationPage.js
+++ b/client/src/pages/VisualizationPage.js
@@ -1,22 +1,19 @@
 import React, { useContext, useState, useMemo } from 'react';
 import { Grid, Paper, Typography } from '@mui/material';
 import { DataContext } from '../context/DataContext';
-import Filters from '../components/Filter';
+import Filter from '../components/Filter';
 import SummaryCard from '../components/SummaryCard';
 import BarGraph from '../components/BarGraph';
 import { format, parseISO } from 'date-fns';
 
 const VisualizationPage = () => {
     const { actions, logs } = useContext(DataContext);
-    const [categories, setCategories] = useState(['Good', 'Bad']);
     const [actionFilters, setActionFilters] = useState([]);
 
     const filteredLogs = useMemo(() => {
-        const filteredActions = actions.filter(a => categories.includes(a.category));
-        const actionIds = filteredActions.map(a => a.id);
-        const finalActionIds = actionFilters.length > 0 ? actionFilters : actionIds;
-        return logs.filter(log => finalActionIds.includes(log.actionId));
-    }, [actions, logs, categories, actionFilters]);
+        const actionIds = actionFilters.length > 0 ? actionFilters : actions.map((a) => a.id);
+        return logs.filter((log) => actionIds.includes(log.actionId));
+    }, [actions, logs, actionFilters]);
 
     const graphData = useMemo(() => {
         const dateMap = {};
@@ -30,9 +27,7 @@ const VisualizationPage = () => {
     return (
         <Grid container spacing={2}>
             <Grid item xs={12}>
-                <Filters
-                    categories={categories}
-                    setCategories={setCategories}
+                <Filter
                     actionFilters={actionFilters}
                     setActionFilters={setActionFilters}
                 />


### PR DESCRIPTION
## Summary
- Remove logs when their action is deleted
- Load and record logs with IDs to allow editing
- Introduce editable/deletable log list and streamline visualization filters

## Testing
- `CI=true npm test` *(fails: No tests found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e1b4c7288832dbd9ef29342ed5cbe