### PR TITLE
Enable custom categories and log deletion

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,13 +1,18 @@
 import React, { useState, useMemo, useEffect } from 'react';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
-import { Box, AppBar, Toolbar, Typography, Button } from '@mui/material';
+import { Box, AppBar, Toolbar, Typography, Button, CssBaseline } from '@mui/material';
 import ActionPage from './pages/ActionPage';
 import VisualizationPage from './pages/VisualizationPage';
 import { DataContext } from './context/DataContext';
 import { getLocalData, setLocalData } from './utils/indexedDBUtil';
 
-const theme = createTheme();
+const theme = createTheme({
+  palette: {
+    primary: { main: '#1976d2' },
+    secondary: { main: '#9c27b0' }
+  }
+});
 
 function App() {
   const [actions, setActions] = useState([]);
@@ -36,8 +41,9 @@ function App() {
 
   return (
     <ThemeProvider theme={theme}>
+      <CssBaseline />
       <Router>
-        <AppBar position="static">
+        <AppBar position="static" color="primary" enableColorOnDark>
           <Toolbar>
             <Typography variant="h6" sx={{ flexGrow: 1 }}>
               Action Tracker

--- a/client/src/components/ActionForm.js
+++ b/client/src/components/ActionForm.js
@@ -1,9 +1,9 @@
 import React, { useState, useEffect } from 'react';
-import { TextField, Button, RadioGroup, FormControlLabel, Radio, Box } from '@mui/material';
+import { TextField, Button, Box, Autocomplete } from '@mui/material';
 
-const ActionForm = ({ onSave, editAction, onCancel }) => {
+const ActionForm = ({ onSave, editAction, onCancel, existingCategories = [] }) => {
     const [name, setName] = useState('');
-    const [category, setCategory] = useState('Good');
+    const [category, setCategory] = useState('');
 
     useEffect(() => {
         if (editAction) {
@@ -16,7 +16,7 @@ const ActionForm = ({ onSave, editAction, onCancel }) => {
         e.preventDefault();
         onSave({ name, category, id: editAction ? editAction.id : Date.now() });
         setName('');
-        setCategory('Good');
+        setCategory('');
     };
 
     return (
@@ -30,10 +30,21 @@ const ActionForm = ({ onSave, editAction, onCancel }) => {
                 required
                 sx={{ mb: 2 }}
             />
-            <RadioGroup row value={category} onChange={(e) => setCategory(e.target.value)}>
-                <FormControlLabel value="Good" control={<Radio />} label="Good" />
-                <FormControlLabel value="Bad" control={<Radio />} label="Bad" />
-            </RadioGroup>
+            <Autocomplete
+                freeSolo
+                options={existingCategories}
+                value={category}
+                onInputChange={(_, newValue) => setCategory(newValue)}
+                renderInput={(params) => (
+                    <TextField
+                        {...params}
+                        label="Category"
+                        required
+                        variant="outlined"
+                        sx={{ mb: 2 }}
+                    />
+                )}
+            />
             <Box sx={{ mt: 2 }}>
                 <Button type="submit" variant="contained" color="primary">
                     {editAction ? 'Update Action' : 'Add Action'}

--- a/client/src/components/Actionsbar.js
+++ b/client/src/components/Actionsbar.js
@@ -1,12 +1,14 @@
-import React, { useState, useContext } from 'react';
+import React, { useState, useContext, useMemo } from 'react';
 import { DataContext } from '../context/DataContext';
 import ActionForm from './ActionForm';
 import { List, ListItem, ListItemText, IconButton, Divider, Typography, Box } from '@mui/material';
 import { Edit, Delete } from '@mui/icons-material';
 
 const Actionsbar = () => {
-    const { actions, setActions } = useContext(DataContext);
+    const { actions, setActions, logs, setLogs } = useContext(DataContext);
     const [editAction, setEditAction] = useState(null);
+
+    const categories = useMemo(() => Array.from(new Set(actions.map(a => a.category))), [actions]);
 
     const handleSave = (action) => {
         if (editAction) {
@@ -23,13 +25,19 @@ const Actionsbar = () => {
 
     const handleDelete = (id) => {
         setActions(actions.filter((a) => a.id !== id));
+        setLogs(logs.filter((l) => l.actionId !== id));
         if (editAction && editAction.id === id) setEditAction(null);
     };
 
     return (
         <Box>
             <Typography variant="h6" gutterBottom>Manage Actions</Typography>
-            <ActionForm onSave={handleSave} editAction={editAction} onCancel={() => setEditAction(null)} />
+            <ActionForm
+                onSave={handleSave}
+                editAction={editAction}
+                onCancel={() => setEditAction(null)}
+                existingCategories={categories}
+            />
             <Divider sx={{ my: 2 }} />
             <List>
                 {actions.map((action) => (

--- a/client/src/components/BarGraph.js
+++ b/client/src/components/BarGraph.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTheme } from '@mui/material/styles';
 import {
     BarChart,
     Bar,
@@ -6,19 +7,31 @@ import {
     YAxis,
     Tooltip,
     CartesianGrid,
-    ResponsiveContainer
+    ResponsiveContainer,
+    LabelList
 } from 'recharts';
 
-const BarGraph = ({ data }) => (
-    <ResponsiveContainer width="100%" height={300}>
-        <BarChart data={data}>
-            <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="date" />
-            <YAxis allowDecimals={false} />
-            <Tooltip />
-            <Bar dataKey="count" fill="#8884d8" />
-        </BarChart>
-    </ResponsiveContainer>
-);
+const BarGraph = ({ data }) => {
+    const theme = useTheme();
+    return (
+        <ResponsiveContainer width="100%" height={300}>
+            <BarChart data={data} margin={{ top: 20, right: 30, left: 0, bottom: 5 }}>
+                <defs>
+                    <linearGradient id="colorCount" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="5%" stopColor={theme.palette.primary.light} stopOpacity={0.8} />
+                        <stop offset="95%" stopColor={theme.palette.primary.main} stopOpacity={0.8} />
+                    </linearGradient>
+                </defs>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="date" />
+                <YAxis allowDecimals={false} />
+                <Tooltip />
+                <Bar dataKey="count" fill="url(#colorCount)" radius={[4, 4, 0, 0]}>
+                    <LabelList dataKey="count" position="top" />
+                </Bar>
+            </BarChart>
+        </ResponsiveContainer>
+    );
+};
 
 export default BarGraph;

--- a/client/src/components/Filter.js
+++ b/client/src/components/Filter.js
@@ -13,7 +13,8 @@ import {
 
 const Filter = ({ actionFilters, setActionFilters }) => {
     const { actions } = useContext(DataContext);
-    const categories = ['Good', 'Bad'];
+
+    const categories = Array.from(new Set(actions.map((a) => a.category)));
 
     const groupedActions = categories.map((category) => ({
         category,

--- a/client/src/components/LogAction.js
+++ b/client/src/components/LogAction.js
@@ -1,6 +1,19 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useState, useMemo } from 'react';
 import { DataContext } from '../context/DataContext';
-import { Box, FormControl, InputLabel, Select, MenuItem, Button, ListSubheader } from '@mui/material';
+import {
+    Box,
+    FormControl,
+    InputLabel,
+    Select,
+    MenuItem,
+    Button,
+    ListSubheader,
+    List,
+    ListItem,
+    ListItemText,
+    IconButton
+} from '@mui/material';
+import { Delete } from '@mui/icons-material';
 
 const LogAction = () => {
     const { actions, logs, setLogs } = useContext(DataContext);
@@ -13,44 +26,68 @@ const LogAction = () => {
         }
     };
 
-    const goodActions = actions
-        .filter((a) => a.category === 'Good')
-        .sort((a, b) => a.name.localeCompare(b.name));
-    const badActions = actions
-        .filter((a) => a.category === 'Bad')
-        .sort((a, b) => a.name.localeCompare(b.name));
+    const groupedActions = useMemo(() => {
+        const groups = {};
+        actions.forEach((a) => {
+            if (!groups[a.category]) groups[a.category] = [];
+            groups[a.category].push(a);
+        });
+        Object.values(groups).forEach((arr) => arr.sort((a, b) => a.name.localeCompare(b.name)));
+        return groups;
+    }, [actions]);
+
+    const handleDeleteLog = (timestamp) => {
+        setLogs(logs.filter((l) => l.timestamp !== timestamp));
+    };
 
     return (
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-            <FormControl sx={{ minWidth: 200 }}>
-                <InputLabel id="action-select-label">Select Action</InputLabel>
-                <Select
-                    labelId="action-select-label"
-                    value={selectedAction ?? ''}
-                    label="Select Action"
-                    onChange={(e) => setSelectedAction(Number(e.target.value))}
-                >
-                    {goodActions.length > 0 && [
-                        <ListSubheader key="good-header">Good</ListSubheader>,
-                        ...goodActions.map((a) => (
-                            <MenuItem key={a.id} value={a.id}>
-                                {a.name}
-                            </MenuItem>
-                        ))
-                    ]}
-                    {badActions.length > 0 && [
-                        <ListSubheader key="bad-header">Bad</ListSubheader>,
-                        ...badActions.map((a) => (
-                            <MenuItem key={a.id} value={a.id}>
-                                {a.name}
-                            </MenuItem>
-                        ))
-                    ]}
-                </Select>
-            </FormControl>
-            <Button variant="contained" onClick={handleLog}>
-                Log Action
-            </Button>
+        <Box>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+                <FormControl sx={{ minWidth: 200 }}>
+                    <InputLabel id="action-select-label">Select Action</InputLabel>
+                    <Select
+                        labelId="action-select-label"
+                        value={selectedAction ?? ''}
+                        label="Select Action"
+                        onChange={(e) => setSelectedAction(Number(e.target.value))}
+                    >
+                        {Object.entries(groupedActions).map(([category, acts]) => [
+                            <ListSubheader key={`${category}-header`}>{category}</ListSubheader>,
+                            ...acts.map((a) => (
+                                <MenuItem key={a.id} value={a.id}>
+                                    {a.name}
+                                </MenuItem>
+                            ))
+                        ])}
+                    </Select>
+                </FormControl>
+                <Button variant="contained" onClick={handleLog}>
+                    Log Action
+                </Button>
+            </Box>
+            <List>
+                {logs
+                    .slice()
+                    .sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp))
+                    .map((log) => {
+                        const action = actions.find((a) => a.id === log.actionId);
+                        return (
+                            <ListItem
+                                key={log.timestamp}
+                                secondaryAction={
+                                    <IconButton edge="end" onClick={() => handleDeleteLog(log.timestamp)}>
+                                        <Delete />
+                                    </IconButton>
+                                }
+                            >
+                                <ListItemText
+                                    primary={action ? action.name : 'Unknown Action'}
+                                    secondary={new Date(log.timestamp).toLocaleString()}
+                                />
+                            </ListItem>
+                        );
+                    })}
+            </List>
         </Box>
     );
 };

--- a/client/src/pages/VisualizationPage.js
+++ b/client/src/pages/VisualizationPage.js
@@ -8,15 +8,13 @@ import { format, parseISO } from 'date-fns';
 
 const VisualizationPage = () => {
     const { actions, logs } = useContext(DataContext);
-    const [categories, setCategories] = useState(['Good', 'Bad']);
     const [actionFilters, setActionFilters] = useState([]);
 
     const filteredLogs = useMemo(() => {
-        const filteredActions = actions.filter(a => categories.includes(a.category));
-        const actionIds = filteredActions.map(a => a.id);
+        const actionIds = actions.map(a => a.id);
         const finalActionIds = actionFilters.length > 0 ? actionFilters : actionIds;
         return logs.filter(log => finalActionIds.includes(log.actionId));
-    }, [actions, logs, categories, actionFilters]);
+    }, [actions, logs, actionFilters]);
 
     const graphData = useMemo(() => {
         const dateMap = {};
@@ -31,8 +29,6 @@ const VisualizationPage = () => {
         <Grid container spacing={2}>
             <Grid item xs={12}>
                 <Filters
-                    categories={categories}
-                    setCategories={setCategories}
                     actionFilters={actionFilters}
                     setActionFilters={setActionFilters}
                 />


### PR DESCRIPTION
## Summary
- allow creating actions with custom categories
- delete logs when actions or log entries are removed
- refresh UI styling and enhance bar graph visuals

## Testing
- `npm test --prefix client -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68b63ae71854832d818b73cdb2511b60